### PR TITLE
Add + before UseG1GC

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 java \
   -Xms${JAVA_MEMORY} \
   -Xmx${JAVA_MEMORY} \
-  -XX:UseG1GC \
+  -XX:+UseG1GC \
   -XX:G1HeapRegionSize=4M \
   -XX:+UnlockExperimentalVMOptions \
   -XX:+ParallelRefProcEnabled \


### PR DESCRIPTION
I am using `FROM openjdk:17-alpine` and UseG1GC is not working.  
Also, velocity doc uses +UseG1GC. Is this symbol necessary?