### PR TITLE
Add Docker stage to query PaperMC Download API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+velocity.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM adoptopenjdk/openjdk11:alpine-slim
+FROM ruby:3 AS builder
+ARG VELOCITY_VERSION=3.1.1
+COPY fetch-velocity.rb .
+RUN ruby fetch-velocity.rb $VELOCITY_VERSION
 
-ARG VELOCITY_VERSION=3.1.0
-ENV VELOCITY_JAR_URL=https://versions.velocitypowered.com/download/${VELOCITY_VERSION}.jar
-
+FROM adoptopenjdk/openjdk11:alpine-slim AS production
 RUN mkdir /velocity
 WORKDIR /velocity
-RUN wget -O velocity.jar $VELOCITY_JAR_URL
-
 RUN mkdir plugins
 RUN mkdir logs
 COPY velocity.toml .
 COPY run.sh .
+COPY --from=builder velocity.jar .
 
 CMD ["/velocity/run.sh"]

--- a/fetch-velocity.rb
+++ b/fetch-velocity.rb
@@ -1,0 +1,73 @@
+require "json"
+require "open-uri"
+
+class VelocityVersion
+  PAPER_API = "https://papermc.io/api/v2"
+
+  attr_reader :build_info, :version
+
+  def initialize(version)
+    @version = version
+  end
+
+  def download_path
+    if has_builds?
+      @build_info = get_latest_promoted_build || get_build_info(build_numbers.last)
+      return get_download_path_for_build(build_info)
+    end
+  end
+
+  def has_builds?
+    version_info["builds"] && version_info["builds"].length > 0
+  end
+
+  def version_info
+    @version_info ||= fetch("/projects/velocity/versions/#{version}")
+  end
+
+  private
+
+  def get_latest_promoted_build
+    build_numbers.reverse.each do |build_number|
+      build_info = get_build_info(build_number)
+      return build_info if build_info["promoted"]
+    end
+
+    return false
+  end
+
+  def get_build_info(build_number)
+    fetch("/projects/velocity/versions/#{version}/builds/#{build_number}")
+  end
+
+  def get_download_path_for_build(build_info)
+    version   = build_info["version"]
+    build     = build_info["build"]
+    filename  = build_info["downloads"]["application"]["name"]
+    "#{PAPER_API}/projects/velocity/versions/#{version}/builds/#{build}/downloads/#{filename}"
+  end
+
+  def fetch(path)
+    JSON.parse(URI("#{PAPER_API}#{path}").read)
+  rescue OpenURI::HTTPError
+    {}
+  end
+
+  def build_numbers
+    @build_numbers ||= version_info["builds"]
+  end
+end
+
+version = VelocityVersion.new(ARGV[0])
+if !version.has_builds?
+  $stderr.puts "Could not find builds for version #{version.version} of Velocity!"
+  exit 1
+end
+
+if download_path = version.download_path
+  `wget -O velocity.jar #{download_path}`
+  puts "Downloaded #{version.version} build #{version.build_info["build"]} to velocity.jar"
+else
+  $stderr.puts "Could not retrieve download path for #{version.version}}!"
+  exit 1
+end


### PR DESCRIPTION
As noted in #2, Versions of Velocity > 3.1.0 are only accessible via a Build number which has to be queried via [API](https://paper.readthedocs.io/en/latest/site/api.html#).  In order to facilitate this, a script has been written that queries the three API endpoints needed to get a download path:

- Versions API
- Builds API
- Downloads API

As these are JSON APIs and the openjdk11:alpine-slim image contains no tooling to do JSON parsing, a builder stage was added to the Dockerfile to determine the download path and download the JAR.  This JAR is then copied into the final build stage to keep the Docker image small.

This could have been solved by pulling in jq via apk into the final image and running a shell script but that would have been much harder to read and more likely to bust a layer cache.